### PR TITLE
Added update check

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ const app = electron.app
 const BrowserWindow = electron.BrowserWindow
 // const Tray = electron.Tray
 const client = require('electron-connect').client
+const update = require('./update')
 
 require('electron-debug')();
 require('electron-dl')();
@@ -82,6 +83,9 @@ function createWindow(){
   // tray.on('click', () => {
   //   mainWindow.isVisible() ? mainWindow.hide() : mainWindow.show()
   // })
+
+  // Don't block rendering with update dialog, wait a bit before checking
+  setTimeout(function () { update.check() }, 8000)
 }
 
 // This method will be called when Electron has finished

--- a/update.js
+++ b/update.js
@@ -1,0 +1,46 @@
+const electron = require('electron')
+const https = require('https')
+
+const shell = electron.shell
+const app = electron.app
+
+function updateDialog (newVersion) {
+  let versionMessage = electron.dialog.showMessageBox({
+    type: 'info',
+    title: `Update available`,
+    message: `${app.getName()} ${newVersion} is available`,
+    buttons: [`Download now`, 'Remind me later'],
+    cancelId: 3
+  })
+
+  if (versionMessage === 0) {
+    shell.openExternal('https://github.com/oskarkrawczyk/overcast-mac/releases')
+  }
+}
+
+function errorDialog () {
+  electron.dialog.showMessageBox({
+    type: 'error',
+    title: `Ups, Something went wrong`,
+    message: `Unable to check for new updates at the moment`,
+    buttons: ['Try later']
+  })
+}
+
+exports.check = () => {
+  https.get('https://raw.githubusercontent.com/oskarkrawczyk/overcast-mac/master/package.json', res => {
+    if (!res.error && res.statusCode === 200) {
+      let body = ''
+      res.on('data', d => { body += d })
+      res.on('end', () => {
+        let json = JSON.parse(body)
+        let newestVersion = json.version
+        if (newestVersion > app.getVersion()) {
+          updateDialog(newestVersion)
+        }
+      })
+    } else {
+      errorDialog()
+    }
+  })
+}


### PR DESCRIPTION
#2: Added update check on startup (Delayed to prevent UI rendering from being blocked).

If you plan to use release, replace `package.json` link with this: `https://api.github.com/repos/oskarkrawczyk/overcast-mac/releases/latest`

You need to build to test update functionality. In dev mode `app.getVersion()` doesn't work because it uses Electron version.
